### PR TITLE
feat: expose the internal compiler options

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ Beautiful reporting for [webpack-sane-compiler](https://github.com/moxystudio/we
 ```js
 const startReporting = require('webpack-sane-compiler-reporter');
 
-const stopReporting = startReporting(compiler, {/* options */});
+const { stop, options } = startReporting(compiler, {/* options */});
 
-// Call compiler.run() or compiler.watch() to start a compilation and start outputting reports
-// Additionally, calling stopReporting() will stop listening to the compiler events
+// Now, just call compiler.run() or compiler.watch() to start a compilation and start outputting reports
+// Calling stop() will stop listening to the compiler events
+// Furthermore, you have access to the options that were computed by the merge of provided options and the defaults
 ```
-
 
 ### Available options:
 
@@ -70,7 +70,7 @@ reporter(compiler, {
 
 ## Tests
 
-`$ npm test`
+`$ npm test`   
 `$ npm test -- --watch` during development
 
 

--- a/index.js
+++ b/index.js
@@ -58,7 +58,10 @@ function startReporting(compiler, options) {
     options.printSuccess && compiler.on('end', onEnd);
     options.printError && compiler.on('error', onError);
 
-    return stopReporting;
+    return {
+        stop: stopReporting,
+        options,
+    };
 }
 
 module.exports = startReporting;

--- a/test/__snapshots__/reporter.spec.js.snap
+++ b/test/__snapshots__/reporter.spec.js.snap
@@ -42,7 +42,7 @@ Error message
 "
 `;
 
-exports[`reporter stopReporting does not output anymore after calling stopReporting 1`] = `
+exports[`reporter returned object does not output anymore after calling stop 1`] = `
 "● Compiling...
 ✔ Compilation succeeded (100ms)
 
@@ -50,6 +50,18 @@ Asset    Size
 foo.js   10Kb
 
 "
+`;
+
+exports[`reporter returned object should provide the internal options 1`] = `
+Object {
+  "printError": [Function],
+  "printFailure": [Function],
+  "printStart": [Function],
+  "printStats": [Function],
+  "printSuccess": [Function],
+  "stats": false,
+  "write": [Function],
+}
 `;
 
 exports[`reporter success allows displaying stats only on the first compilation 1`] = `

--- a/test/reporter.spec.js
+++ b/test/reporter.spec.js
@@ -166,23 +166,31 @@ describe('reporter', () => {
         });
     });
 
-    describe('stopReporting', () => {
-        it('does not output anymore after calling stopReporting', () => {
+    describe('returned object', () => {
+        it('does not output anymore after calling stop', () => {
             const compiler = createCompiler();
             const writter = createWritter();
             const stats = createStats();
 
-            const stopReporting = createReporter(compiler, { write: writter });
+            const { stop } = createReporter(compiler, { write: writter });
 
             compiler.emit('begin');
             compiler.emit('end', stats);
 
-            stopReporting();
+            stop();
 
             compiler.emit('begin');
             compiler.emit('end', stats);
 
             expect(writter.getOutput()).toMatchSnapshot();
+        });
+
+        it('should provide the internal options', () => {
+            const compiler = createCompiler();
+
+            const { options } = createReporter(compiler, { stats: false });
+
+            expect(options).toMatchSnapshot();
         });
     });
 });


### PR DESCRIPTION
BREAKING CHANGE: the return of the startReporting is now an object