### PR TITLE
feat: pass stats and err to print success and print failure respectively

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ const { stop, options } = startReporting(compiler, {/* options */});
 
 ### API
 
-As shown in the [usage](#usage) section abose, the result of adding reporting on a compiler is a function that, when invoked, stops listening to the compiler events, hence halting any further output.
+As shown in the [usage](#usage) section above, the result of adding reporting on a compiler is a function that, when invoked, stops listening to the compiler events, hence halting any further output.
 
 ### Other exports
 
@@ -62,7 +62,7 @@ For convenience (or fun) this package also exports the default render methods:
 const reporter = require('webpack-sane-compiler-reporter');
 
 reporter(compiler, {
-    printSuccess: () => reporter.renderers.renderError(new Error('Nope!')), // ¯\_(ツ)_/¯
+    printSuccess: (stats) => reporter.renderers.renderSuccess(stats),
 });
 
 ```

--- a/test/__snapshots__/reporter.spec.js.snap
+++ b/test/__snapshots__/reporter.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`reporter error allows decorating an error with a code or name 1`] = `
+exports[`reporter failed build allows decorating an error with a code or name 1`] = `
 "● Compiling...
 ✖ Compilation failed
 
@@ -10,7 +10,7 @@ exports[`reporter error allows decorating an error with a code or name 1`] = `
 "
 `;
 
-exports[`reporter error allows decorating an error with a code or name 2`] = `
+exports[`reporter failed build allows decorating an error with a code or name 2`] = `
 "✖ Compilation failed
 
 Syntax error: Error message
@@ -19,7 +19,7 @@ Syntax error: Error message
 "
 `;
 
-exports[`reporter error allows hiding the stats from the output 1`] = `
+exports[`reporter failed build allows hiding the stats from the output 1`] = `
 "● Compiling...
 ✖ Compilation failed
 
@@ -29,7 +29,7 @@ Error message
 "
 `;
 
-exports[`reporter error renders the correct output 1`] = `
+exports[`reporter failed build renders the correct output 1`] = `
 "● Compiling...
 ✖ Compilation failed
 
@@ -42,13 +42,13 @@ Error message
 "
 `;
 
-exports[`reporter returned object does not output anymore after calling stop 1`] = `
-"● Compiling...
-✔ Compilation succeeded (100ms)
-
-Asset    Size
-foo.js   10Kb
-
+exports[`reporter printers should allow overriding the various print options 1`] = `
+"start
+success
+stats
+start
+failure
+err
 "
 `;
 
@@ -64,7 +64,17 @@ Object {
 }
 `;
 
-exports[`reporter success allows displaying stats only on the first compilation 1`] = `
+exports[`reporter returned object should stop reporting if stop is called 1`] = `
+"● Compiling...
+✔ Compilation succeeded (100ms)
+
+Asset    Size
+foo.js   10Kb
+
+"
+`;
+
+exports[`reporter successful build should display stats only on the first compilation if \`options.stats\` is once 1`] = `
 "● Compiling...
 ✔ Compilation succeeded (100ms)
 
@@ -83,14 +93,14 @@ foo.js   10Kb
 "
 `;
 
-exports[`reporter success allows hiding the stats from the output 1`] = `
+exports[`reporter successful build should hide the stats from the output if \`options.stats\` is false 1`] = `
 "● Compiling...
 ✔ Compilation succeeded (100ms)
 
 "
 `;
 
-exports[`reporter success renders the correct output 1`] = `
+exports[`reporter successful build should render the correct output 1`] = `
 "● Compiling...
 ✔ Compilation succeeded (100ms)
 
@@ -100,17 +110,8 @@ foo.js   10Kb
 "
 `;
 
-exports[`reporter success resets the displayStats logic when a run finishes 1`] = `
+exports[`reporter successful build should reset the displayStats logic when a run finishes 1`] = `
 "● Compiling...
-✔ Compilation succeeded (100ms)
-
-Asset    Size
-foo.js   10Kb
-
-● Compiling...
-✔ Compilation succeeded (100ms)
-
-● Compiling...
 ✔ Compilation succeeded (100ms)
 
 Asset    Size
@@ -119,10 +120,19 @@ foo.js   10Kb
 ● Compiling...
 ✔ Compilation succeeded (100ms)
 
+● Compiling...
+✔ Compilation succeeded (100ms)
+
+Asset    Size
+foo.js   10Kb
+
+● Compiling...
+✔ Compilation succeeded (100ms)
+
 "
 `;
 
-exports[`reporter success resets the displayStats logic when an unwatch is called 1`] = `
+exports[`reporter successful build should reset the displayStats logic when an unwatch is called 1`] = `
 "● Compiling...
 ✔ Compilation succeeded (100ms)
 


### PR DESCRIPTION
This gives more flexibility and is necessary for the webpack-isomorphic-compiler-reporter.

BREAKING CHANGE: the printers signature is different